### PR TITLE
Update redis-as-a-caching-backend.md

### DIFF
--- a/source/docs/articles/sites/redis-as-a-caching-backend.md
+++ b/source/docs/articles/sites/redis-as-a-caching-backend.md
@@ -37,7 +37,7 @@ For detailed information, see [Installing Redis on WordPress](/docs/articles/wor
 
 ### Drupal 7.x and 6.x Sites
 
-1. Add [the Redis module](http://drupal.org/project/redis) from Drupal.org. Only the 7.x-2.x branch of the Redis module is currently supported for Drupal 7.x sites on Pantheon.
+1. Add [the Redis module](http://drupal.org/project/redis) from Drupal.org.
 
  As there is no Redis module for Drupal 6.x, you need to install the [Cache Backport](https://drupal.org/project/cache_backport) module to use Redis with Drupal 6.x. See [more information](/docs/articles/sites/redis-as-a-caching-backend/#drupal-6-cache-backport) in the Troubleshooting section below.
 


### PR DESCRIPTION
latest version of redis module works, so doesnt need to be version specific

did not include $conf['path_inc'] = 'sites/all/modules/redis/redis.path.inc';